### PR TITLE
Fix some DHT session bugs

### DIFF
--- a/examples/client_test.cpp
+++ b/examples/client_test.cpp
@@ -179,7 +179,7 @@ int main(int argc, char const* argv[])
 		e.assign(content);
 		std::vector<scout::entry> entries;
 		entries.push_back(e);
-		ses.synchronize(shared_secret, entries
+		ses.synchronize(shared_secret, std::move(entries)
 			, [](entry const&) {}
 			, [=](std::vector<entry>& entries)
 			{

--- a/include/dht_session.hpp
+++ b/include/dht_session.hpp
@@ -73,7 +73,7 @@ public:
 	// synchronize a list of entries with the DHT
 	// this will first update the given vector with any new or updated entries from the DHT
 	// then store the updated list in the DHT
-	void synchronize(secret_key_span shared_key, std::vector<entry> const& entries
+	void synchronize(secret_key_span shared_key, std::vector<entry> entries
 		, entry_updated entry_cb, finalize_entries finalize_cb, sync_finished finished_cb);
 
 	// store an immutable item in the DHT

--- a/src/dht_session.cpp
+++ b/src/dht_session.cpp
@@ -591,18 +591,18 @@ void dht_session::stop()
 {
 	if (m_state != RUNNING) return;
 	m_state = QUITTING;
-	m_dht->Enable(false, 0);
+	m_dht->Shutdown();
 	m_dht_timer.cancel();
 	m_ios.stop();
 	m_thread.join();
 }
 
-void dht_session::synchronize(secret_key_span shared_key, std::vector<entry> const& entries
+void dht_session::synchronize(secret_key_span shared_key, std::vector<entry> entries
 	, entry_updated entry_cb, finalize_entries finalize_cb, sync_finished finished_cb)
 {
-	m_ios.post([=,&entries]()
+	m_ios.post([=, captured_entries = std::move(entries)]()
 	{
-		::synchronize(*m_dht, shared_key, entries, entry_cb, finalize_cb, finished_cb);
+		::synchronize(*m_dht, shared_key, captured_entries, entry_cb, finalize_cb, finished_cb);
 	});
 }
 


### PR DESCRIPTION
- make sure we call Shutdown() upon stopping the session,
this will ensure that we save the state to dht.dat
- pass the entries vector by value and move it into the lambda to ensure the entries don't go out of scope (since the lambda will run on the DHT thread)